### PR TITLE
Add missing colon to flake8 error ignores (# noqa\

### DIFF
--- a/license_xsl/bootstrap/bootstrap.py
+++ b/license_xsl/bootstrap/bootstrap.py
@@ -64,9 +64,9 @@ if is_jython:
     import subprocess
 
     assert subprocess.Popen([sys.executable] + ["-c", quote(cmd), "-mqNxd",
-           quote(tmpeggs), "zc.buildout" + VERSION],  # noqa E128: preserving syntactic sugar
+           quote(tmpeggs), "zc.buildout" + VERSION],  # noqa: E128: preserving syntactic sugar
            env=dict(os.environ,
-               PYTHONPATH=  # noqa E251
+               PYTHONPATH=  # noqa: E251
                ws.find(pkg_resources.Requirement.parse("setuptools")).location
                ),
            ).wait() == 0
@@ -76,13 +76,13 @@ else:
         os.P_WAIT, sys.executable, quote(sys.executable),
         "-c", quote(cmd), "-mqNxd", quote(tmpeggs), "zc.buildout" + VERSION,
         dict(os.environ,
-            PYTHONPATH=  # noqa E128, E251: preserving syntactic sugar
+            PYTHONPATH=  # noqa: E128, E251: preserving syntactic sugar
             ws.find(pkg_resources.Requirement.parse("setuptools")).location
             ),
         ) == 0
 
 ws.add_entry(tmpeggs)
 ws.require("zc.buildout" + VERSION)
-import zc.buildout.buildout  # noqa E402: assuming that this is at the end for a reason
+import zc.buildout.buildout  # noqa: E402: assuming that this is at the end for a reason
 zc.buildout.buildout.main(args)
 shutil.rmtree(tmpeggs)

--- a/license_xsl/licensexsl_tools/convert.py
+++ b/license_xsl/licensexsl_tools/convert.py
@@ -26,7 +26,7 @@ def get_dirname_of_this_file():
 def get_default_pofile_path():
     return os.path.join(get_dirname_of_this_file(), "../i18n/i18n_po/")
 
-POFILE_PATH=get_default_pofile_path()  # noqa E305
+POFILE_PATH=get_default_pofile_path()  # noqa: E305
 
 
 def key2canonical(key):
@@ -43,7 +43,7 @@ def key2canonical(key):
 Output: a po file string that has the same contents as
 the original PO file, but the keys have been replaced with
 canonical values for those keys."""
-def pofd2converted(pofd):  # noqa E302: ignoring because of docstring 
+def pofd2converted(pofd):  # noqa: E302: ignoring because of docstring 
     r = babel.messages.pofile.read_po(pofd)
     # r._messages is a mapping from string ID to Message object
     # Message objects should have .string gotten from them
@@ -71,7 +71,7 @@ def pofd2converted(pofd):  # noqa E302: ignoring because of docstring
 
 
 pofile_cache = dict()
-def get_PoFile(language, use_cache=True):  # noqa E302
+def get_PoFile(language, use_cache=True):  # noqa: E302
     global pofile_cache
 
     if (not use_cache) or (language not in pofile_cache):

--- a/license_xsl/licensexsl_tools/convert_zpt.py
+++ b/license_xsl/licensexsl_tools/convert_zpt.py
@@ -24,7 +24,7 @@ def key2en(key):
 
 # sample input: <span i18n:translate="country.mk" />
 # sample output: <span i18n:translate="">Macedonia</span>
-def convert_zpt_string(s):  # noqa E302
+def convert_zpt_string(s):  # noqa: E302
     try:
         u = unicode(s)
     except Exception:
@@ -75,7 +75,7 @@ def convert_zpt_dom_elements(elts):
 
                 # Step 3
                 i18n_value_as_unicode = unicode(key2en(i18n_key))
-                i18n_value_as_raw_dom_elts = i18nstring2dom_elts(i18n_value_as_unicode)  # noqa E501
+                i18n_value_as_raw_dom_elts = i18nstring2dom_elts(i18n_value_as_unicode)  # noqa: E501
 
                 # Step 4
                 # Then, we modify the raw parsed i18n DOM elements

--- a/license_xsl/licensexsl_tools/licenses.py
+++ b/license_xsl/licensexsl_tools/licenses.py
@@ -129,7 +129,7 @@ def addLicense(filename, jurisdiction, version, licenses):
                 if w.get("id") == jurisdiction:
                     # If it"s there, add in the new version.
                     found = 1
-                    print "Adding version {} to existing jurisdiction {}.".format(  # noqa E501
+                    print "Adding version {} to existing jurisdiction {}.".format(  # noqa: E501
                           version, jurisdiction)
                     newelem = w.makeelement("version", None)
                     newelem.set("id", version)
@@ -137,7 +137,7 @@ def addLicense(filename, jurisdiction, version, licenses):
                     if jurisdiction != "-":
                         j = "{}/".format(jurisdiction)
                     newelem.set("uri",
-                                "http://creativecommons.org/licenses/{}/{}/{}".format( # noqa E501
+                                "http://creativecommons.org/licenses/{}/{}/{}".format( # noqa: E501
                                     v.get("id"),
                                     version,
                                     j)

--- a/license_xsl/licensexsl_tools/translate.py
+++ b/license_xsl/licensexsl_tools/translate.py
@@ -46,7 +46,7 @@ def fix_tags(input_string):
     # convert & to &amp;
     input_string = re.sub("&(?!amp;)", "&amp;", input_string)
 
-    tag_re = re.compile("<([\w]+)([\w\t =\"']*)>")  # noqa W605: ignoring because in RegEx
+    tag_re = re.compile("<([\w]+)([\w\t =\"']*)>")  # noqa: W605: ignoring because in RegEx
     match = re.match(tag_re, input_string)
 
     if not(match):
@@ -231,7 +231,7 @@ def main():
         # re-read the temp file and parse it for well-formed-ness
         try:
             print "validating XML structure of {}...".format(temp_fn)
-            tree = et.parse(temp_fn)  # noqa F841
+            tree = et.parse(temp_fn)  # noqa: F841
 
         except Exception, e:
             print


### PR DESCRIPTION
## Description
*the colon before the list of codes is required otherwise the part after noqa is ignored* (https://gitlab.com/pycqa/flake8)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
